### PR TITLE
Update cyber_reading_list.md

### DIFF
--- a/cyber_reading_list.md
+++ b/cyber_reading_list.md
@@ -87,3 +87,4 @@
 - [ ] The Matrix (movie)
 - [ ] Mr. Robot (TV Series)
 - [ ] Snow Crash (book)
+- [ ] WarGames (movie, 1983)


### PR DESCRIPTION
Adding proposed media under Entertainment for the movie WarGames (1983).  Film gives a quick glance at the paranoia generated around computer hacking which eventually shaped some laws being implemented in the 1980's such as the CFAA.